### PR TITLE
fix probe targeting

### DIFF
--- a/AnoPrimer/design.py
+++ b/AnoPrimer/design.py
@@ -179,14 +179,11 @@ def prepare_gDNA_sequence(
     }
 
     if "probe" in assay_type:
-        seq_parameters["SEQUENCE_INTERNAL_EXCLUDED_REGION"] = [
-            [1, target_loc_primer3[0] - probe_exclude_region_size],
-            [
-                target_loc_primer3[0] + probe_exclude_region_size,
-                len(target_sequence)
-                - (target_loc_primer3[0] + probe_exclude_region_size),
-            ],
+        seq_parameters["SEQUENCE_INTERNAL_OVERLAP_JUNCTION_LIST"] = [
+            target_loc_primer3[0]
         ]
+        seq_parameters["PRIMER_MIN_3_PRIME_OVERLAP_OF_JUNCTION"] = 3
+        seq_parameters["PRIMER_MIN_5_PRIME_OVERLAP_OF_JUNCTION"] = 3
 
     return seq_parameters
 

--- a/AnoPrimer/evaluate.py
+++ b/AnoPrimer/evaluate.py
@@ -270,6 +270,9 @@ class AnoPrimerResults:
             print("No exons in close proximity for loc plot")
             return
 
+        # remove duplicate exons from different transcripts
+        locgff = locgff.drop_duplicates("Name")
+
         # Set up the plot
         fig, ax = plt.subplots(1, 1, figsize=[16, 4])
         self._configure_plot_axes(ax, min_, max_, start, end)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "AnoPrimer"
-version = "2.0.4"
+version = "2.0.5"
 description = "A package to design primers in Anopheles gambiae whilst considering genetic variation with malariagen_data"
 readme = "README.md"
 documentation = "https://sanjaynagi.github.io/anoprimer/latest/"

--- a/tests/run_ci_notebooks.sh
+++ b/tests/run_ci_notebooks.sh
@@ -1,8 +1,7 @@
-
+papermill notebooks/AnoPrimer-long.ipynb tests/probe_run.ipynb -k AnoPrimer -f tests/probe_Params.json &&
 papermill notebooks/AnoPrimer-long.ipynb tests/qPCR_run.ipynb -k AnoPrimer -f tests/cDNA_Params.json &&
 papermill notebooks/AnoPrimer-long.ipynb tests/qPCR2_run.ipynb -k AnoPrimer -f tests/cDNA_Params_2.json &&
 papermill notebooks/AnoPrimer-long.ipynb tests/gDNA_run.ipynb -k AnoPrimer -f tests/gDNA_probe_Params.json &&
-papermill notebooks/AnoPrimer-long.ipynb tests/probe_run.ipynb -k AnoPrimer -f tests/probe_Params.json &&
 papermill notebooks/AnoPrimer-long.ipynb tests/qPCR_run.ipynb -k AnoPrimer -f tests/cDNA_Params_fun.json &&
 papermill notebooks/AnoPrimer-long.ipynb tests/qPCR2_run.ipynb -k AnoPrimer -f tests/cDNA_Params_2_fun.json &&
 papermill notebooks/AnoPrimer-long.ipynb tests/gDNA_run.ipynb -k AnoPrimer -f tests/gDNA_probe_Params_fun.json &&


### PR DESCRIPTION
Previously we used a very roundabout method to target the probe, by excluding non-wanted regions. The way I did this was marginally wrong though (it did not exclude quite enough space), and so sometimes the probe could miss the actual target. 

I've found a simpler primer3 parameter, 'SEQUENCE_INTERNAL_OVERLAP_JUNCTION_LIST,' which will make the probe overlap the target SNP. I don't know if this was available when I first started using primer3-py (some options were not implemented in an earlier version), or I just missed it. 